### PR TITLE
Fix mobile playback overlays, adaptive controls, and global video scaling

### DIFF
--- a/fermata/src/main/java/me/aap/fermata/media/lib/ItemBase.java
+++ b/fermata/src/main/java/me/aap/fermata/media/lib/ItemBase.java
@@ -221,6 +221,7 @@ public abstract class ItemBase implements Item, MediaPrefs, SharedPreferenceStor
 
 	@Override
 	public String getPreferenceKey(Pref<?> key) {
+		if (MediaPrefs.VIDEO_SCALE.getName().equals(key.getName())) return key.getName();
 		return getId() + "#" + key.getName();
 	}
 

--- a/fermata/src/main/java/me/aap/fermata/ui/fragment/FloatingButtonMediator.java
+++ b/fermata/src/main/java/me/aap/fermata/ui/fragment/FloatingButtonMediator.java
@@ -28,13 +28,17 @@ public class FloatingButtonMediator implements BackMenu {
 	@Override
 	public void enable(FloatingButton fb, ActivityFragment f) {
 		BackMenu.super.enable(fb, f);
-		if (BuildConfig.AUTO) fb.setVisibility(View.GONE);
+		updateVisibility(fb, MainActivityDelegate.get(fb.getContext()), f);
 	}
 
 	@Override
 	public void onActivityEvent(FloatingButton fb, me.aap.utils.ui.activity.ActivityDelegate a, long e) {
 		BackMenu.super.onActivityEvent(fb, a, e);
-		if (BuildConfig.AUTO) fb.setVisibility(View.GONE);
+		if (a instanceof MainActivityDelegate main) {
+			updateVisibility(fb, main, main.getActiveFragment());
+		} else if (BuildConfig.AUTO) {
+			fb.setVisibility(View.GONE);
+		}
 	}
 
 	@Override
@@ -89,6 +93,18 @@ public class FloatingButtonMediator implements BackMenu {
 		}
 
 		return null;
+	}
+
+	private static void updateVisibility(FloatingButton fb, MainActivityDelegate a,
+			@Nullable ActivityFragment f) {
+		fb.setVisibility(shouldHide(a, f) ? View.GONE : View.VISIBLE);
+	}
+
+	static boolean shouldHide(MainActivityDelegate a, @Nullable ActivityFragment f) {
+		if (BuildConfig.AUTO || a.isVideoMode()) return true;
+		if (f == null) return false;
+		int id = f.getFragmentId();
+		return (id == R.id.youtube_fragment) || (id == R.id.web_browser_fragment);
 	}
 
 	private boolean isAddFolderEnabled(ActivityFragment f) {

--- a/fermata/src/main/java/me/aap/fermata/ui/policy/ControlPanelSizingPolicy.java
+++ b/fermata/src/main/java/me/aap/fermata/ui/policy/ControlPanelSizingPolicy.java
@@ -1,0 +1,27 @@
+package me.aap.fermata.ui.policy;
+
+/** Pure geometry for transport controls. Keeps hit cells layout-owned while sizing visuals to the
+ * actual measured cell instead of fixed dp glyph assumptions. */
+public final class ControlPanelSizingPolicy {
+	private static final float GLYPH_RATIO = 0.52F;
+
+	private ControlPanelSizingPolicy() {
+	}
+
+	public static Geometry resolve(int width, int height) {
+		int w = Math.max(0, width);
+		int h = Math.max(0, height);
+		int visual = Math.min(w, h);
+		int glyph = (visual == 0) ? 0 : Math.max(1, Math.round(visual * GLYPH_RATIO));
+		int horizontalPadding = Math.max(0, (w - glyph) / 2);
+		int verticalPadding = Math.max(0, (h - glyph) / 2);
+		int backgroundInsetX = Math.max(0, (w - visual) / 2);
+		int backgroundInsetY = Math.max(0, (h - visual) / 2);
+		return new Geometry(visual, glyph, horizontalPadding, verticalPadding,
+				backgroundInsetX, backgroundInsetY);
+	}
+
+	public record Geometry(int visualSize, int glyphSize, int horizontalPadding,
+			int verticalPadding, int backgroundInsetX, int backgroundInsetY) {
+	}
+}

--- a/fermata/src/main/java/me/aap/fermata/ui/view/AdaptiveTransportButton.java
+++ b/fermata/src/main/java/me/aap/fermata/ui/view/AdaptiveTransportButton.java
@@ -1,0 +1,66 @@
+package me.aap.fermata.ui.view;
+
+import android.content.Context;
+import android.graphics.drawable.Drawable;
+import android.graphics.drawable.InsetDrawable;
+import android.util.AttributeSet;
+
+import androidx.annotation.Nullable;
+
+import me.aap.fermata.R;
+import me.aap.fermata.ui.policy.ControlPanelSizingPolicy;
+
+/**
+ * Weighted transport cells keep their full touch/focus area, while the glyph and the primary
+ * background are sized from the cell actually allocated by ConstraintLayout. This avoids tiny
+ * fixed-padding glyphs on narrow phones and oversized/non-square primary surfaces on wide screens.
+ */
+public class AdaptiveTransportButton extends me.aap.utils.ui.view.ImageButton {
+	@Nullable
+	private Drawable baseBackground;
+	private boolean constructed;
+
+	public AdaptiveTransportButton(Context context, @Nullable AttributeSet attrs) {
+		this(context, attrs, androidx.appcompat.R.attr.imageButtonStyle);
+	}
+
+	public AdaptiveTransportButton(Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+		super(context, attrs, defStyleAttr);
+		constructed = true;
+		baseBackground = getBackground();
+	}
+
+	@Override
+	public void setBackgroundResource(int resId) {
+		super.setBackgroundResource(resId);
+		if (!constructed) return;
+		baseBackground = getBackground();
+		applyAdaptiveGeometry(getWidth(), getHeight());
+	}
+
+	@Override
+	protected void onSizeChanged(int w, int h, int oldw, int oldh) {
+		super.onSizeChanged(w, h, oldw, oldh);
+		applyAdaptiveGeometry(w, h);
+	}
+
+	private void applyAdaptiveGeometry(int width, int height) {
+		if ((width <= 0) || (height <= 0)) return;
+		ControlPanelSizingPolicy.Geometry geometry =
+				ControlPanelSizingPolicy.resolve(width, height);
+		setPadding(geometry.horizontalPadding(), geometry.verticalPadding(),
+				geometry.horizontalPadding(), geometry.verticalPadding());
+
+		if (getId() != R.id.control_play_pause) return;
+		Drawable background = baseBackground;
+		if (background == null) {
+			background = getBackground();
+			baseBackground = background;
+		}
+		if (background == null) return;
+
+		int insetX = geometry.backgroundInsetX();
+		int insetY = geometry.backgroundInsetY();
+		super.setBackground(new InsetDrawable(background, insetX, insetY, insetX, insetY));
+	}
+}

--- a/fermata/src/main/java/me/aap/fermata/ui/view/ControlPanelView.java
+++ b/fermata/src/main/java/me/aap/fermata/ui/view/ControlPanelView.java
@@ -110,10 +110,17 @@ public class ControlPanelView extends ConstraintLayout
 
 		ViewGroup g = findViewById(R.id.show_hide_bars);
 		showHideBars = (ImageView) g.getChildAt(0);
-		bindBackControl(g);
+		View seekTime = findViewById(R.id.seek_time);
+		if (isAutoUi(a)) {
+			bindBackControl(g);
+			bindBackControl(seekTime);
+		} else {
+			disableBackControl(g);
+			disableBackControl(seekTime);
+			showHideBars.setVisibility(GONE);
+		}
 		showHideBars.setClickable(false);
 		showHideBars.setFocusable(false);
-		bindBackControl(findViewById(R.id.seek_time));
 		g = findViewById(R.id.control_menu_button);
 		g.setOnClickListener(this::showMenu);
 		favoriteController = new PlayerFavoriteButtonController(a, findViewById(R.id.control_favorite));
@@ -124,6 +131,13 @@ public class ControlPanelView extends ConstraintLayout
 		v.setClickable(true);
 		v.setOnClickListener(this::backOrShowHideBars);
 		v.setOnTouchListener(this::backOrShowHideBarsTouch);
+	}
+
+	private static void disableBackControl(View v) {
+		v.setClickable(false);
+		v.setFocusable(false);
+		v.setOnClickListener(null);
+		v.setOnTouchListener(null);
 	}
 
 	@Nullable
@@ -535,12 +549,7 @@ public class ControlPanelView extends ConstraintLayout
 
 	private void backOrShowHideBars(View v) {
 		MainActivityDelegate a = getActivity();
-		if (isAutoUi(a)) {
-			performAutoPlayerBack(a);
-		} else {
-			a.setBarsHidden(!a.isBarsHidden());
-			setShowHideBarsIcon(a);
-		}
+		if (isAutoUi(a)) performAutoPlayerBack(a);
 	}
 
 	private boolean backOrShowHideBarsTouch(View v, MotionEvent e) {
@@ -654,9 +663,14 @@ public class ControlPanelView extends ConstraintLayout
 	}
 
 	private void setShowHideBarsIcon(MainActivityDelegate a) {
-		a.post(() -> showHideBars.setImageResource(
-				isAutoUi(a) ? me.aap.utils.R.drawable.back :
-						a.isBarsHidden() ? R.drawable.expand : me.aap.utils.R.drawable.collapse));
+		a.post(() -> {
+			if (!isAutoUi(a)) {
+				showHideBars.setVisibility(GONE);
+				return;
+			}
+			showHideBars.setVisibility(VISIBLE);
+			showHideBars.setImageResource(me.aap.utils.R.drawable.back);
+		});
 	}
 
 	private static boolean isAutoUi(MainActivityDelegate a) {
@@ -720,7 +734,7 @@ public class ControlPanelView extends ConstraintLayout
 			MediaEngine eng = getActivity().getMediaSessionCallback().getEngine();
 			if (eng == null) return;
 			AudioStreamInfo ai = eng.getCurrentAudioStreamInfo();
-			List<AudioStreamInfo> streams = eng.getAudioStreamInfo();
+			List<AudioStreamInfo> streams = engine.getAudioStreamInfo();
 			b.setSelectionHandler(this::audioStreamSelected);
 
 			for (int i = 0; i < streams.size(); i++) {

--- a/fermata/src/main/java/me/aap/fermata/ui/view/ControlPanelView.java
+++ b/fermata/src/main/java/me/aap/fermata/ui/view/ControlPanelView.java
@@ -734,7 +734,7 @@ public class ControlPanelView extends ConstraintLayout
 			MediaEngine eng = getActivity().getMediaSessionCallback().getEngine();
 			if (eng == null) return;
 			AudioStreamInfo ai = eng.getCurrentAudioStreamInfo();
-			List<AudioStreamInfo> streams = engine.getAudioStreamInfo();
+			List<AudioStreamInfo> streams = eng.getAudioStreamInfo();
 			b.setSelectionHandler(this::audioStreamSelected);
 
 			for (int i = 0; i < streams.size(); i++) {

--- a/fermata/src/main/res/layout/control_panel_view.xml
+++ b/fermata/src/main/res/layout/control_panel_view.xml
@@ -132,12 +132,12 @@
         <me.aap.utils.ui.view.ImageButton
             android:id="@+id/control_favorite"
             style="?attr/appControlPanelStyle"
-            android:layout_width="32dp"
+            android:layout_width="@dimen/control_panel_edge_action_size"
             android:layout_height="match_parent"
             android:background="@drawable/focusable_shape_transparent"
             android:clickable="true"
             android:focusable="true"
-            android:padding="8dp"
+            android:padding="@dimen/control_panel_edge_action_padding"
             android:scaleType="fitCenter"
             android:src="@drawable/favorite"
             android:visibility="gone" />

--- a/fermata/src/main/res/layout/control_panel_view.xml
+++ b/fermata/src/main/res/layout/control_panel_view.xml
@@ -153,7 +153,7 @@
             android:src="@drawable/more" />
     </LinearLayout>
 
-    <me.aap.utils.ui.view.ImageButton
+    <me.aap.fermata.ui.view.AdaptiveTransportButton
         android:id="@+id/control_prev"
         style="?attr/appControlPanelStyle"
         android:layout_width="0dp"
@@ -172,7 +172,7 @@
         app:layout_constraintStart_toStartOf="@id/control_panel_transport_start"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <me.aap.utils.ui.view.ImageButton
+    <me.aap.fermata.ui.view.AdaptiveTransportButton
         android:id="@+id/control_rw"
         style="?attr/appControlPanelStyle"
         android:layout_width="0dp"
@@ -190,7 +190,7 @@
         app:layout_constraintStart_toEndOf="@id/control_prev"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <me.aap.utils.ui.view.ImageButton
+    <me.aap.fermata.ui.view.AdaptiveTransportButton
         android:id="@+id/control_play_pause"
         style="?attr/appControlPanelStyle"
         android:layout_width="0dp"
@@ -209,7 +209,7 @@
         app:layout_constraintTop_toTopOf="parent"
         app:tint="?android:attr/colorBackground" />
 
-    <me.aap.utils.ui.view.ImageButton
+    <me.aap.fermata.ui.view.AdaptiveTransportButton
         android:id="@+id/control_ff"
         style="?attr/appControlPanelStyle"
         android:layout_width="0dp"
@@ -227,7 +227,7 @@
         app:layout_constraintStart_toEndOf="@id/control_play_pause"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <me.aap.utils.ui.view.ImageButton
+    <me.aap.fermata.ui.view.AdaptiveTransportButton
         android:id="@+id/control_next"
         style="?attr/appControlPanelStyle"
         android:layout_width="0dp"

--- a/fermata/src/main/res/layout/control_panel_view2.xml
+++ b/fermata/src/main/res/layout/control_panel_view2.xml
@@ -133,12 +133,12 @@
         <me.aap.utils.ui.view.ImageButton
             android:id="@+id/control_favorite"
             style="?attr/appControlPanelStyle"
-            android:layout_width="32dp"
+            android:layout_width="@dimen/control_panel_edge_action_size"
             android:layout_height="match_parent"
             android:background="@drawable/focusable_shape_transparent"
             android:clickable="true"
             android:focusable="true"
-            android:padding="8dp"
+            android:padding="@dimen/control_panel_edge_action_padding"
             android:scaleType="fitCenter"
             android:src="@drawable/favorite"
             android:visibility="gone" />

--- a/fermata/src/main/res/layout/control_panel_view2.xml
+++ b/fermata/src/main/res/layout/control_panel_view2.xml
@@ -154,7 +154,7 @@
             android:src="@drawable/more" />
     </LinearLayout>
 
-    <me.aap.utils.ui.view.ImageButton
+    <me.aap.fermata.ui.view.AdaptiveTransportButton
         android:id="@+id/control_prev"
         style="?attr/appControlPanelStyle"
         android:layout_width="0dp"
@@ -173,7 +173,7 @@
         app:layout_constraintStart_toStartOf="@id/control_panel_transport_start"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <me.aap.utils.ui.view.ImageButton
+    <me.aap.fermata.ui.view.AdaptiveTransportButton
         android:id="@+id/control_rw"
         style="?attr/appControlPanelStyle"
         android:layout_width="0dp"
@@ -191,7 +191,7 @@
         app:layout_constraintStart_toEndOf="@id/control_prev"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <me.aap.utils.ui.view.ImageButton
+    <me.aap.fermata.ui.view.AdaptiveTransportButton
         android:id="@+id/control_play_pause"
         style="?attr/appControlPanelStyle"
         android:layout_width="0dp"
@@ -210,7 +210,7 @@
         app:layout_constraintTop_toTopOf="parent"
         app:tint="?android:attr/colorBackground" />
 
-    <me.aap.utils.ui.view.ImageButton
+    <me.aap.fermata.ui.view.AdaptiveTransportButton
         android:id="@+id/control_ff"
         style="?attr/appControlPanelStyle"
         android:layout_width="0dp"
@@ -228,7 +228,7 @@
         app:layout_constraintStart_toEndOf="@id/control_play_pause"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <me.aap.utils.ui.view.ImageButton
+    <me.aap.fermata.ui.view.AdaptiveTransportButton
         android:id="@+id/control_next"
         style="?attr/appControlPanelStyle"
         android:layout_width="0dp"

--- a/fermata/src/test/java/me/aap/fermata/ui/policy/ControlPanelSizingPolicyTest.java
+++ b/fermata/src/test/java/me/aap/fermata/ui/policy/ControlPanelSizingPolicyTest.java
@@ -1,0 +1,40 @@
+package me.aap.fermata.ui.policy;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class ControlPanelSizingPolicyTest {
+	@Test
+	public void narrowCellScalesGlyphAndKeepsPrimarySurfaceSquare() {
+		ControlPanelSizingPolicy.Geometry g = ControlPanelSizingPolicy.resolve(44, 64);
+		assertEquals(44, g.visualSize());
+		assertEquals(23, g.glyphSize());
+		assertEquals(10, g.horizontalPadding());
+		assertEquals(20, g.verticalPadding());
+		assertEquals(0, g.backgroundInsetX());
+		assertEquals(10, g.backgroundInsetY());
+	}
+
+	@Test
+	public void wideCellCentersAReasonableVisualWithoutGrowingWithTheWholeRail() {
+		ControlPanelSizingPolicy.Geometry g = ControlPanelSizingPolicy.resolve(96, 64);
+		assertEquals(64, g.visualSize());
+		assertEquals(33, g.glyphSize());
+		assertEquals(31, g.horizontalPadding());
+		assertEquals(15, g.verticalPadding());
+		assertEquals(16, g.backgroundInsetX());
+		assertEquals(0, g.backgroundInsetY());
+	}
+
+	@Test
+	public void geometryNeverProducesNegativeInsetsOrPadding() {
+		ControlPanelSizingPolicy.Geometry g = ControlPanelSizingPolicy.resolve(1, 1);
+		assertTrue(g.glyphSize() >= 1);
+		assertTrue(g.horizontalPadding() >= 0);
+		assertTrue(g.verticalPadding() >= 0);
+		assertTrue(g.backgroundInsetX() >= 0);
+		assertTrue(g.backgroundInsetY() >= 0);
+	}
+}

--- a/fermata/src/test/java/me/aap/fermata/ui/policy/MobileControlsAndGlobalVideoScaleContractTest.java
+++ b/fermata/src/test/java/me/aap/fermata/ui/policy/MobileControlsAndGlobalVideoScaleContractTest.java
@@ -1,0 +1,56 @@
+package me.aap.fermata.ui.policy;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.Test;
+
+public class MobileControlsAndGlobalVideoScaleContractTest {
+	@Test
+	public void phoneFullscreenNeverRevealsTheFloatingBackOverlay() throws Exception {
+		String chrome = repositorySource(
+				"modules/web/src/main/java/me/aap/fermata/addon/web/FermataChromeClient.java");
+		int touch = chrome.indexOf("protected boolean onTouchEvent(View v, MotionEvent event)");
+		int autoGuard = chrome.indexOf(
+				"if (!a.getRuntimeHostMode().usesAutomotivePresentation())", touch);
+		int phoneGone = chrome.indexOf("fb.setVisibility(GONE);", autoGuard);
+		int autoVisible = chrome.indexOf("fb.setVisibility(VISIBLE);", phoneGone);
+		assertTrue(touch >= 0);
+		assertTrue(autoGuard > touch);
+		assertTrue(phoneGone > autoGuard);
+		assertTrue(autoVisible > phoneGone);
+	}
+
+	@Test
+	public void videoScaleUsesOneLibraryPreferenceKeyAcrossPlayableItems() throws Exception {
+		String itemBase = fermataSource("media/lib/ItemBase.java");
+		String settings = fermataSource("ui/fragment/MediaEnginePrefsBuilder.java");
+		String video = fermataSource("ui/view/VideoView.java");
+		assertTrue(itemBase.contains(
+				"if (MediaPrefs.VIDEO_SCALE.getName().equals(key.getName())) return key.getName();"));
+		assertTrue(settings.contains("o.store = mediaPrefs;"));
+		assertTrue(settings.contains("o.pref = MediaLibPrefs.VIDEO_SCALE;"));
+		assertTrue(video.contains("item.getPrefs().getVideoScalePref()"));
+		assertFalse(itemBase.contains("getId() + \"#\" + MediaPrefs.VIDEO_SCALE.getName()"));
+	}
+
+	private static String fermataSource(String relativePath) throws Exception {
+		return repositorySource("fermata/src/main/java/me/aap/fermata/" + relativePath);
+	}
+
+	private static String repositorySource(String relativePath) throws Exception {
+		return new String(Files.readAllBytes(repositoryRoot().resolve(relativePath)), UTF_8);
+	}
+
+	private static Path repositoryRoot() {
+		Path current = Path.of(System.getProperty("user.dir")).toAbsolutePath();
+		if (Files.isDirectory(current.resolve("fermata/src/main"))) return current;
+		Path parent = current.getParent();
+		if ((parent != null) && Files.isDirectory(parent.resolve("fermata/src/main"))) return parent;
+		throw new AssertionError("Unable to locate repository from " + current);
+	}
+}

--- a/fermata/src/test/java/me/aap/fermata/ui/policy/MobileControlsAndGlobalVideoScaleContractTest.java
+++ b/fermata/src/test/java/me/aap/fermata/ui/policy/MobileControlsAndGlobalVideoScaleContractTest.java
@@ -26,6 +26,29 @@ public class MobileControlsAndGlobalVideoScaleContractTest {
 	}
 
 	@Test
+	public void phoneWebAndYoutubeNeverOwnTheFloatingBackButton() throws Exception {
+		String mediator = fermataSource("ui/fragment/FloatingButtonMediator.java");
+		assertTrue(mediator.contains("updateVisibility(fb, MainActivityDelegate.get(fb.getContext()), f)"));
+		assertTrue(mediator.contains("if (BuildConfig.AUTO || a.isVideoMode()) return true;"));
+		assertTrue(mediator.contains("id == R.id.youtube_fragment"));
+		assertTrue(mediator.contains("id == R.id.web_browser_fragment"));
+		assertTrue(mediator.contains("fb.setVisibility(shouldHide(a, f) ? View.GONE : View.VISIBLE)"));
+	}
+
+	@Test
+	public void transportButtonsUseMeasuredCellGeometryInsteadOfFixedVisualSizing() throws Exception {
+		for (String layout : new String[]{"control_panel_view.xml", "control_panel_view2.xml"}) {
+			String xml = repositorySource("fermata/src/main/res/layout/" + layout);
+			int count = xml.split("me\\.aap\\.fermata\\.ui\\.view\\.AdaptiveTransportButton", -1).length - 1;
+			assertTrue(layout, count == 5);
+		}
+		String button = fermataSource("ui/view/AdaptiveTransportButton.java");
+		assertTrue(button.contains("ControlPanelSizingPolicy.resolve(width, height)"));
+		assertTrue(button.contains("new InsetDrawable(background, insetX, insetY, insetX, insetY)"));
+		assertFalse(button.contains("16dp"));
+	}
+
+	@Test
 	public void videoScaleUsesOneLibraryPreferenceKeyAcrossPlayableItems() throws Exception {
 		String itemBase = fermataSource("media/lib/ItemBase.java");
 		String settings = fermataSource("ui/fragment/MediaEnginePrefsBuilder.java");

--- a/fermata/src/test/java/me/aap/fermata/ui/policy/MobileControlsAndGlobalVideoScaleContractTest.java
+++ b/fermata/src/test/java/me/aap/fermata/ui/policy/MobileControlsAndGlobalVideoScaleContractTest.java
@@ -14,11 +14,17 @@ public class MobileControlsAndGlobalVideoScaleContractTest {
 	public void phoneFullscreenNeverRevealsTheFloatingBackOverlay() throws Exception {
 		String chrome = repositorySource(
 				"modules/web/src/main/java/me/aap/fermata/addon/web/FermataChromeClient.java");
+		int fullScreen = chrome.indexOf("protected void setFullScreen(MainActivityDelegate a, boolean fullScreen)");
 		int touch = chrome.indexOf("protected boolean onTouchEvent(View v, MotionEvent event)");
 		int autoGuard = chrome.indexOf(
 				"if (!a.getRuntimeHostMode().usesAutomotivePresentation())", touch);
 		int phoneGone = chrome.indexOf("fb.setVisibility(GONE);", autoGuard);
 		int autoVisible = chrome.indexOf("fb.setVisibility(VISIBLE);", phoneGone);
+		assertTrue(fullScreen >= 0);
+		assertTrue(chrome.substring(fullScreen, touch)
+				.contains("a.getFloatingButton().setVisibility(GONE);"));
+		assertFalse(chrome.substring(fullScreen, touch)
+				.contains("fullScreen ? GONE : VISIBLE"));
 		assertTrue(touch >= 0);
 		assertTrue(autoGuard > touch);
 		assertTrue(phoneGone > autoGuard);
@@ -41,6 +47,9 @@ public class MobileControlsAndGlobalVideoScaleContractTest {
 			String xml = repositorySource("fermata/src/main/res/layout/" + layout);
 			int count = xml.split("me\\.aap\\.fermata\\.ui\\.view\\.AdaptiveTransportButton", -1).length - 1;
 			assertTrue(layout, count == 5);
+			String favorite = element(xml, "@+id/control_favorite");
+			assertTrue(favorite.contains("android:layout_width=\"@dimen/control_panel_edge_action_size\""));
+			assertTrue(favorite.contains("android:padding=\"@dimen/control_panel_edge_action_padding\""));
 		}
 		String button = fermataSource("ui/view/AdaptiveTransportButton.java");
 		assertTrue(button.contains("ControlPanelSizingPolicy.resolve(width, height)"));
@@ -59,6 +68,13 @@ public class MobileControlsAndGlobalVideoScaleContractTest {
 		assertTrue(settings.contains("o.pref = MediaLibPrefs.VIDEO_SCALE;"));
 		assertTrue(video.contains("item.getPrefs().getVideoScalePref()"));
 		assertFalse(itemBase.contains("getId() + \"#\" + MediaPrefs.VIDEO_SCALE.getName()"));
+	}
+
+	private static String element(String xml, String id) {
+		int at = xml.indexOf(id);
+		int start = xml.lastIndexOf('<', at);
+		int end = xml.indexOf("/>", at);
+		return xml.substring(start, end + 2);
 	}
 
 	private static String fermataSource(String relativePath) throws Exception {

--- a/fermata/src/test/java/me/aap/fermata/ui/view/ControlPanelContractTest.java
+++ b/fermata/src/test/java/me/aap/fermata/ui/view/ControlPanelContractTest.java
@@ -188,12 +188,18 @@ public class ControlPanelContractTest {
 	}
 
 	@Test
-	public void phonePlayerActionStaysCollapseWhileAutomotiveOwnsPlayerBack() throws Exception {
+	public void phonePlayerHasNoEdgeHideActionWhileAutomotiveOwnsPlayerBack() throws Exception {
 		String panel = source("ui/view/ControlPanelView.java");
-		assertTrue(panel.contains("if (isAutoUi(a))"));
+		assertTrue(panel.contains("if (isAutoUi(a)) {"));
+		assertTrue(panel.contains("bindBackControl(g);"));
+		assertTrue(panel.contains("bindBackControl(seekTime);"));
+		assertTrue(panel.contains("disableBackControl(g);"));
+		assertTrue(panel.contains("disableBackControl(seekTime);"));
+		assertTrue(panel.contains("showHideBars.setVisibility(GONE);"));
 		assertTrue(panel.contains("performAutoPlayerBack(a)"));
-		assertTrue(panel.contains("a.setBarsHidden(!a.isBarsHidden())"));
-		assertTrue(panel.contains("isAutoUi(a) ? me.aap.utils.R.drawable.back"));
+		assertFalse(panel.contains("a.setBarsHidden(!a.isBarsHidden())"));
+		assertFalse(panel.contains("R.drawable.expand"));
+		assertTrue(panel.contains("showHideBars.setImageResource(me.aap.utils.R.drawable.back)"));
 		assertTrue(panel.contains("private boolean isAutoBackTouch(MotionEvent e)"));
 		assertTrue(panel.contains("if (!isAutoUi(a)) return false;"));
 		assertFalse(panel.contains("isPlayerBackPresentation"));

--- a/modules/web/src/main/java/me/aap/fermata/addon/web/FermataChromeClient.java
+++ b/modules/web/src/main/java/me/aap/fermata/addon/web/FermataChromeClient.java
@@ -222,7 +222,7 @@ public class FermataChromeClient extends WebChromeClient {
 
 	protected void setFullScreen(MainActivityDelegate a, boolean fullScreen) {
 		a.setVideoMode(fullScreen, null);
-		a.getFloatingButton().setVisibility(fullScreen ? GONE : VISIBLE);
+		a.getFloatingButton().setVisibility(GONE);
 	}
 
 	public boolean canEnterFullScreen() {

--- a/modules/web/src/main/java/me/aap/fermata/addon/web/FermataChromeClient.java
+++ b/modules/web/src/main/java/me/aap/fermata/addon/web/FermataChromeClient.java
@@ -280,6 +280,11 @@ public class FermataChromeClient extends WebChromeClient {
 
 		MainActivityDelegate a = MainActivityDelegate.get(v.getContext());
 		FloatingButton fb = a.getFloatingButton();
+		if (!a.getRuntimeHostMode().usesAutomotivePresentation()) {
+			touchStamp = 0L;
+			fb.setVisibility(GONE);
+			return false;
+		}
 		long st = touchStamp = System.currentTimeMillis();
 
 		fb.setVisibility(VISIBLE);


### PR DESCRIPTION
## Scope
Fix the mobile playback issues together:
1. remove the redundant round floating Back overlay from PHONE Web/YouTube, including the fullscreen-exit path that previously re-enabled it
2. remove the far-left show/hide-playerbar action on PHONE, including its hidden click target, while preserving automotive Player Back
3. make the five transport controls visually adaptive to their actual measured cells instead of fixed visual geometry, so narrow phones no longer shrink secondary glyphs or stretch Play/Pause into a vertical pill
4. align Favorite with the responsive edge-action sizing already used by the playerbar edge controls
5. make core `VIDEO_SCALE` use one media-library preference key instead of an item/channel-prefixed key so scale persists across channel/item switches and native video addon paths

## Implementation
- `FloatingButtonMediator`: PHONE Web and YouTube fragments never own the floating Back button; normal PHONE fragments explicitly restore it when appropriate
- `FermataChromeClient`: Web fullscreen enter/exit always keeps the floating button `GONE`; automotive fullscreen touch behavior remains isolated to the automotive path
- `ControlPanelView`: only automotive binds the left playerbar edge/elapsed-time region to Player Back; PHONE disables those click/touch handlers and hides the edge icon
- `AdaptiveTransportButton` + `ControlPanelSizingPolicy`: glyph size and primary visual surface are derived from the measured transport cell; the touch/focus cell remains layout-owned, while Play/Pause gets a centered square visual surface on both narrow and wide screens
- `control_panel_view*.xml`: all five transport controls use the adaptive view; Favorite uses the responsive edge-action dimensions
- `ItemBase`: `VIDEO_SCALE` resolves to the media-library root key while every other item preference remains item-scoped

## Validation
CI #165 passed on frozen head `f69e51d1b268ef02b2fc0b20e5b5a57300ad20e9`:
- Mobile unit suite
- Auto unit suite
- Architecture boundary guards
- Lint
- PR whitespace check

Focused tests cover narrow/wide adaptive control geometry, Web/YouTube floating-button suppression including fullscreen exit, PHONE/AUTO playerbar ownership, and global video-scale key ownership.
